### PR TITLE
Remove useless '[Discord]' prefix from bridge configuration

### DIFF
--- a/roles/matrix/files/bridge_config.yaml
+++ b/roles/matrix/files/bridge_config.yaml
@@ -68,7 +68,7 @@ room:
 channel:
     # Pattern of the name given to bridged rooms.
     # Can use :guild for the guild name and :name for the channel name.
-    namePattern: "[Discord] :guild :name"
+    namePattern: ":guild :name"
     # Changes made to rooms when a channel is deleted.
     deleteOptions:
        # Prefix the room name with a string.


### PR DESCRIPTION
- It takes half the space in element.io's compact layout.

- As a user, it's just noise I have to skip over to know information
about the group.

- As a user, it's misleading to read the name of another network in a
different network.

- The network backend(s) shouldn't be important to the user; at least
not in a way the user should be constantly aware of.

Signed-off-by: Roosembert Palacios <roosemberth@posteo.ch>